### PR TITLE
Fix torrent ingestion crash due to NOT NULL announce constraint

### DIFF
--- a/seedboxsync/controllers/sync.py
+++ b/seedboxsync/controllers/sync.py
@@ -90,7 +90,7 @@ class Sync(Controller):
                         torrent_info = self.app.bcoding.get_torrent_infos(torrent_file)  # type: ignore[attr-defined]
                         torrent = Torrent.create(name=torrent_name)
                         if torrent_info is not None:
-                            torrent.announce = torrent_info['announce']
+                            torrent.announce = torrent_info.get('announce') or None
                             torrent.save()
 
                             # Remove local torrent file

--- a/seedboxsync/core/dao/torrent.py
+++ b/seedboxsync/core/dao/torrent.py
@@ -25,5 +25,5 @@ class Torrent(SeedboxSyncModel):
     """
 
     name = TextField()
-    announce = TextField()
+    announce = TextField(null=True)
     sent = DateTimeField(default=datetime.datetime.now)

--- a/seedboxsync/core/db.py
+++ b/seedboxsync/core/db.py
@@ -11,6 +11,7 @@ from peewee import SqliteDatabase
 from cement import App  # type: ignore[attr-defined]
 from cement.utils import fs
 from seedboxsync.core.dao import Download, Lock, SeedboxSync, Torrent
+from playhouse.migrate import SchemaMigrator, migrate
 
 
 def extend_db(app: App) -> None:
@@ -49,7 +50,7 @@ class Database:
         db (SqliteDatabase): Peewee database instance.
     """
 
-    DATABASE_VERSION = 2
+    DATABASE_VERSION = 3
     __app: App
     __db_file: str
     db: SqliteDatabase
@@ -139,3 +140,13 @@ class Database:
         @self.db.func('humanize')  # type: ignore
         def db_humanize(num: float) -> str:
             return humanize.filesize.naturalsize(num, True)
+
+    def migrate_to_3(self) -> None:
+        """
+        Migration: allow null values for the 'announce' field in the torrent table.
+        """
+        migrator = SchemaMigrator.from_database(self.db)
+        migrate(
+            migrator.drop_not_null('torrent', 'announce'),
+        )
+        SeedboxSync.set_db_version('3')


### PR DESCRIPTION
## Fix crash when torrent announce field is missing

SeedboxSync crashes with:

sqlite3.IntegrityError: NOT NULL constraint failed: torrent.announce

### Cause
Torrent parser may return missing or null announce field, but database schema enforces NOT NULL constraint.

### Fix
- Safely extract announce using `.get()`
- Avoid inserting None into NOT NULL column
- Align ingestion logic with real-world (private tracker) torrent metadata behavior

### Impact
- Prevents ingestion crashes in watch folder workflow
- Improves compatibility with trackerless or malformed torrents

### Notes
Because the existing SQLite schema defines `announce` as NOT NULL, a database reset or migration may be required depending on the current installation state.